### PR TITLE
Cython examples from scikit-learn, pandas, and scikit-image

### DIFF
--- a/cython/README.md
+++ b/cython/README.md
@@ -1,0 +1,32 @@
+# Cython Examples
+
+This directory contains examples of real Cython code used in other popular
+Python packages.  The equivalent SPy code will (eventually) be found in the
+file with the same name, but a `.spy` extension.  A pytest driver that runs
+both the Cython and SPy files will have the pattern `test_[FILENAME].py`.
+
+## Scikit-Learn
+
+Test scenario: Specialized IntFloatDict class.
+
+Cython: [cython_fast_dict.pyx](https://github.com/scikit-learn/scikit-learn/blob/af7df5ced0eb1124df12dd389cc4ef7a9042837e/sklearn/utils/_fast_dict.pyx)
+SPy: *TBD*
+Demonstrates:
+* Building a fast container class for use from Python
+* Passing arrays
+
+## Pandas
+
+Test scenario: Inner join.
+
+Cython:
+  * [cython_inner_join.pyx](https://github.com/pandas-dev/pandas/blob/e5898b8d33ac943a60250e1466006c073a506e8c/pandas/_libs/join.pyx)
+  * [cython_group_sort_indexer.pyx](https://github.com/pandas-dev/pandas/blob/e5898b8d33ac943a60250e1466006c073a506e8c/pandas/_libs/algos.pyx)
+)
+SPy equivalent:
+Demonstrates:
+* Multi-file linking
+* Array access with wraparound and bounds-checking logic. 
+
+
+Note that all these Cython examples and test files are copyright their original authors with their original license.

--- a/cython/README.md
+++ b/cython/README.md
@@ -23,10 +23,22 @@ Cython:
   * [cython_inner_join.pyx](https://github.com/pandas-dev/pandas/blob/e5898b8d33ac943a60250e1466006c073a506e8c/pandas/_libs/join.pyx)
   * [cython_group_sort_indexer.pyx](https://github.com/pandas-dev/pandas/blob/e5898b8d33ac943a60250e1466006c073a506e8c/pandas/_libs/algos.pyx)
 )
-SPy equivalent:
+SPy: *TBD*
 Demonstrates:
 * Multi-file linking
 * Array access with wraparound and bounds-checking logic. 
 
+## Scikit-image
+
+Test scenario: Non-trivial array calculation used in larger algorithm.
+
+Cython:
+  * [cython_skimage_texture.pyx](https://github.com/scikit-image/scikit-image/blob/866c8794ba86477104e8ed679f66c8e0234677f0/skimage/feature/_texture.pyx
+  )
+    - Also includes [fused type definitions](https://github.com/scikit-image/scikit-image/blob/866c8794ba86477104e8ed679f66c8e0234677f0/skimage/_shared/fused_numerics.pxd) and a [custom definition of the round() function](https://github.com/scikit-image/scikit-image/blob/866c8794ba86477104e8ed679f66c8e0234677f0/skimage/_shared/interpolation.pxd#L25-L28).
+SPy: *TBD*
+Demonstrates:
+* Complex array algorithm.
+* Use of [fused types](https://cython.readthedocs.io/en/stable/src/userguide/fusedtypes.html) to automatically generate multiple specialized signatures of the same function.  (Similar to a C++ template function.)
 
 Note that all these Cython examples and test files are copyright their original authors with their original license.

--- a/cython/cython_fast_dict.pyx
+++ b/cython/cython_fast_dict.pyx
@@ -1,0 +1,143 @@
+# distutils: language = c++
+# From: https://github.com/scikit-learn/scikit-learn/blob/af7df5ced0eb1124df12dd389cc4ef7a9042837e/sklearn/utils/_fast_dict.pyx
+# Modified to run self-contained for this demo
+
+"""
+Uses C++ map containers for fast dict-like behavior with keys being
+integers, and values float.
+"""
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+# C++
+from cython.operator cimport dereference as deref, preincrement as inc
+from libcpp.utility cimport pair
+from libcpp.map cimport map as cpp_map
+
+import numpy as np
+
+ctypedef Py_ssize_t intp_t
+ctypedef double float64_t
+
+
+###############################################################################
+# An object to be used in Python
+
+# Lookup is faster than dict (up to 10 times), and so is full traversal
+# (up to 50 times), and assignment (up to 6 times), but creation is
+# slower (up to 3 times). Also, a large benefit is that memory
+# consumption is reduced a lot compared to a Python dict
+
+cdef class IntFloatDict:
+    cdef cpp_map[intp_t, float64_t] my_map
+
+    def __init__(
+        self,
+        intp_t[:] keys,
+        float64_t[:] values,
+    ):
+        cdef int i
+        cdef int size = values.size
+        # Should check that sizes for keys and values are equal, and
+        # after should boundcheck(False)
+        for i in range(size):
+            self.my_map[keys[i]] = values[i]
+
+    def __len__(self):
+        return self.my_map.size()
+
+    def __getitem__(self, int key):
+        cdef cpp_map[intp_t, float64_t].iterator it = self.my_map.find(key)
+        if it == self.my_map.end():
+            # The key is not in the dict
+            raise KeyError('%i' % key)
+        return deref(it).second
+
+    def __setitem__(self, int key, float value):
+        self.my_map[key] = value
+
+    # Cython 0.20 generates buggy code below. Commenting this out for now
+    # and relying on the to_arrays method
+    # def __iter__(self):
+    #     cdef cpp_map[intp_t, float64_t].iterator it = self.my_map.begin()
+    #     cdef cpp_map[intp_t, float64_t].iterator end = self.my_map.end()
+    #     while it != end:
+    #         yield deref(it).first, deref(it).second
+    #         inc(it)
+
+    def __iter__(self):
+        cdef int size = self.my_map.size()
+        cdef intp_t [:] keys = np.empty(size, dtype=np.intp)
+        cdef float64_t [:] values = np.empty(size, dtype=np.float64)
+        self._to_arrays(keys, values)
+        cdef int idx
+        cdef intp_t key
+        cdef float64_t value
+        for idx in range(size):
+            key = keys[idx]
+            value = values[idx]
+            yield key, value
+
+    def to_arrays(self):
+        """Return the key, value representation of the IntFloatDict
+           object.
+
+           Returns
+           =======
+           keys : ndarray, shape (n_items, ), dtype=int
+                The indices of the data points
+           values : ndarray, shape (n_items, ), dtype=float
+                The values of the data points
+        """
+        cdef int size = self.my_map.size()
+        keys = np.empty(size, dtype=np.intp)
+        values = np.empty(size, dtype=np.float64)
+        self._to_arrays(keys, values)
+        return keys, values
+
+    cdef _to_arrays(self, intp_t [:] keys, float64_t [:] values):
+        # Internal version of to_arrays that takes already-initialized arrays
+        cdef cpp_map[intp_t, float64_t].iterator it = self.my_map.begin()
+        cdef cpp_map[intp_t, float64_t].iterator end = self.my_map.end()
+        cdef int index = 0
+        while it != end:
+            keys[index] = deref(it).first
+            values[index] = deref(it).second
+            inc(it)
+            index += 1
+
+    def update(self, IntFloatDict other):
+        cdef cpp_map[intp_t, float64_t].iterator it = other.my_map.begin()
+        cdef cpp_map[intp_t, float64_t].iterator end = other.my_map.end()
+        while it != end:
+            self.my_map[deref(it).first] = deref(it).second
+            inc(it)
+
+    def copy(self):
+        cdef IntFloatDict out_obj = IntFloatDict.__new__(IntFloatDict)
+        # The '=' operator is a copy operator for C++ maps
+        out_obj.my_map = self.my_map
+        return out_obj
+
+    def append(self, intp_t key, float64_t value):
+        # Construct our arguments
+        cdef pair[intp_t, float64_t] args
+        args.first = key
+        args.second = value
+        self.my_map.insert(args)
+
+
+###############################################################################
+# operation on dict
+
+def argmin(IntFloatDict d):
+    cdef cpp_map[intp_t, float64_t].iterator it = d.my_map.begin()
+    cdef cpp_map[intp_t, float64_t].iterator end = d.my_map.end()
+    cdef intp_t min_key = -1
+    cdef float64_t min_value = np.inf
+    while it != end:
+        if deref(it).second < min_value:
+            min_value = deref(it).second
+            min_key = deref(it).first
+        inc(it)
+    return min_key, min_value

--- a/cython/cython_group_sort_indexer.pyx
+++ b/cython/cython_group_sort_indexer.pyx
@@ -1,0 +1,82 @@
+# From: https://github.com/pandas-dev/pandas/blob/e5898b8d33ac943a60250e1466006c073a506e8c/pandas/_libs/algos.pyx
+cimport cython
+from cython cimport Py_ssize_t
+
+import numpy as np
+
+from numpy cimport (
+    NPY_FLOAT64,
+    NPY_INT8,
+    NPY_INT16,
+    NPY_INT32,
+    NPY_INT64,
+    NPY_OBJECT,
+    NPY_UINT64,
+    float32_t,
+    float64_t,
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    intp_t,
+    ndarray,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def groupsort_indexer(const intp_t[:] index, Py_ssize_t ngroups):
+    """
+    Compute a 1-d indexer.
+
+    The indexer is an ordering of the passed index,
+    ordered by the groups.
+
+    Parameters
+    ----------
+    index: np.ndarray[np.intp]
+        Mappings from group -> position.
+    ngroups: int64
+        Number of groups.
+
+    Returns
+    -------
+    ndarray[intp_t, ndim=1]
+        Indexer
+    ndarray[intp_t, ndim=1]
+        Group Counts
+
+    Notes
+    -----
+    This is a reverse of the label factorization process.
+    """
+    cdef:
+        Py_ssize_t i, label, n
+        intp_t[::1] indexer, where, counts
+
+    counts = np.zeros(ngroups + 1, dtype=np.intp)
+    n = len(index)
+    indexer = np.zeros(n, dtype=np.intp)
+    where = np.zeros(ngroups + 1, dtype=np.intp)
+
+    with nogil:
+
+        # count group sizes, location 0 for NA
+        for i in range(n):
+            counts[index[i] + 1] += 1
+
+        # mark the start of each contiguous group of like-indexed data
+        for i in range(1, ngroups + 1):
+            where[i] = where[i - 1] + counts[i - 1]
+
+        # this is our indexer
+        for i in range(n):
+            label = index[i] + 1
+            indexer[where[label]] = i
+            where[label] += 1
+
+    return indexer.base, counts.base

--- a/cython/cython_inner_join.pyx
+++ b/cython/cython_inner_join.pyx
@@ -1,0 +1,106 @@
+# From: https://github.com/pandas-dev/pandas/blob/e5898b8d33ac943a60250e1466006c073a506e8c/pandas/_libs/join.pyx#L24
+
+cimport cython
+from cython cimport Py_ssize_t
+import numpy as np
+
+cimport numpy as cnp
+from numpy cimport (
+    int64_t,
+    intp_t,
+    ndarray,
+)
+
+cnp.import_array()
+
+from cython_group_sort_indexer import groupsort_indexer
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+def inner_join(const intp_t[:] left, const intp_t[:] right,
+               Py_ssize_t max_groups, bint sort=True):
+    cdef:
+        Py_ssize_t i, j, k, count = 0
+        intp_t[::1] left_sorter, right_sorter
+        intp_t[::1] left_count, right_count
+        intp_t[::1] left_indexer, right_indexer
+        intp_t lc, rc
+        Py_ssize_t left_pos = 0, right_pos = 0, position = 0
+        Py_ssize_t offset
+
+    left_sorter, left_count = groupsort_indexer(left, max_groups)
+    right_sorter, right_count = groupsort_indexer(right, max_groups)
+
+    with nogil:
+        # First pass, determine size of result set, do not use the NA group
+        for i in range(1, max_groups + 1):
+            lc = left_count[i]
+            rc = right_count[i]
+
+            if rc > 0 and lc > 0:
+                count += lc * rc
+
+    left_indexer = np.empty(count, dtype=np.intp)
+    right_indexer = np.empty(count, dtype=np.intp)
+
+    with nogil:
+        # exclude the NA group
+        left_pos = left_count[0]
+        right_pos = right_count[0]
+        for i in range(1, max_groups + 1):
+            lc = left_count[i]
+            rc = right_count[i]
+
+            if rc > 0 and lc > 0:
+                for j in range(lc):
+                    offset = position + j * rc
+                    for k in range(rc):
+                        left_indexer[offset + k] = left_pos + j
+                        right_indexer[offset + k] = right_pos + k
+                position += lc * rc
+            left_pos += lc
+            right_pos += rc
+
+        # Will overwrite left/right indexer with the result
+        _get_result_indexer(left_sorter, left_indexer)
+        _get_result_indexer(right_sorter, right_indexer)
+
+    if not sort:
+        # if not asked to sort, revert to original order
+        if len(left) == len(left_indexer):
+            # no multiple matches for any row on the left
+            # this is a short-cut to avoid groupsort_indexer
+            # otherwise, the `else` path also works in this case
+            rev = np.empty(len(left), dtype=np.intp)
+            rev.put(np.asarray(left_sorter), np.arange(len(left)))
+        else:
+            rev, _ = groupsort_indexer(left_indexer, len(left))
+
+        return np.asarray(left_indexer).take(rev), np.asarray(right_indexer).take(rev)
+    else:
+        return np.asarray(left_indexer), np.asarray(right_indexer)
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+cdef void _get_result_indexer(
+    const intp_t[::1] sorter,
+    intp_t[::1] indexer,
+) noexcept nogil:
+    """NOTE: overwrites indexer with the result to avoid allocating another array"""
+    cdef:
+        Py_ssize_t i, n, idx
+
+    if len(sorter) > 0:
+        # cython-only equivalent to
+        #  `res = algos.take_nd(sorter, indexer, fill_value=-1)`
+        n = indexer.shape[0]
+        for i in range(n):
+            idx = indexer[i]
+            if idx == -1:
+                indexer[i] = -1
+            else:
+                indexer[i] = sorter[idx]
+    else:
+        # length-0 case
+        indexer[:] = -1

--- a/cython/cython_skimage_texture.pyx
+++ b/cython/cython_skimage_texture.pyx
@@ -1,0 +1,102 @@
+# From: https://github.com/scikit-image/scikit-image/blob/866c8794ba86477104e8ed679f66c8e0234677f0/skimage/feature/_texture.pyx
+
+#cython: cdivision=True
+#cython: boundscheck=False
+#cython: nonecheck=False
+#cython: wraparound=False
+import numpy as np
+cimport numpy as cnp
+from libc.math cimport sin, cos
+
+cdef extern from "numpy/npy_math.h":
+    cnp.float64_t NAN "NPY_NAN"
+
+# From: https://github.com/scikit-image/scikit-image/blob/866c8794ba86477104e8ed679f66c8e0234677f0/skimage/_shared/fused_numerics.pxd
+ctypedef fused np_ints:
+    cnp.int8_t
+    cnp.int16_t
+    cnp.int32_t
+    cnp.int64_t
+
+ctypedef fused np_uints:
+    cnp.uint8_t
+    cnp.uint16_t
+    cnp.uint32_t
+    cnp.uint64_t
+
+ctypedef fused np_anyint:
+    np_uints
+    np_ints
+
+ctypedef fused np_floats:
+    cnp.float32_t
+    cnp.float64_t
+###
+
+# From: https://github.com/scikit-image/scikit-image/blob/866c8794ba86477104e8ed679f66c8e0234677f0/skimage/_shared/interpolation.pxd#L25-L28
+
+cdef inline Py_ssize_t round(np_floats r) noexcept nogil:
+    return <Py_ssize_t>(
+        (r + <np_floats>0.5) if (r > <np_floats>0.0) else (r - <np_floats>0.5)
+    )
+
+###
+ctypedef np_anyint any_int
+
+cnp.import_array()
+
+def _glcm_loop(any_int[:, ::1] image, cnp.float64_t[:] distances,
+               cnp.float64_t[:] angles, Py_ssize_t levels,
+               cnp.uint32_t[:, :, :, ::1] out):
+    """Perform co-occurrence matrix accumulation.
+
+    Parameters
+    ----------
+    image : ndarray
+        Integer typed input image. Only positive valued images are supported.
+        If type is other than uint8, the argument `levels` needs to be set.
+    distances : ndarray
+        List of pixel pair distance offsets.
+    angles : ndarray
+        List of pixel pair angles in radians.
+    levels : int
+        The input image should contain integers in [0, `levels`-1],
+        where levels indicate the number of gray-levels counted
+        (typically 256 for an 8-bit image).
+    out : ndarray
+        On input a 4D array of zeros, and on output it contains
+        the results of the GLCM computation.
+
+    """
+
+    cdef:
+        Py_ssize_t a_idx, d_idx, r, c, rows, cols, row, col, start_row,\
+                   end_row, start_col, end_col, offset_row, offset_col
+        any_int i, j
+        cnp.float64_t angle, distance
+
+    with nogil:
+        rows = image.shape[0]
+        cols = image.shape[1]
+
+        for a_idx in range(angles.shape[0]):
+            angle = angles[a_idx]
+            for d_idx in range(distances.shape[0]):
+                distance = distances[d_idx]
+                offset_row = round(sin(angle) * distance)
+                offset_col = round(cos(angle) * distance)
+                start_row = max(0, -offset_row)
+                end_row = min(rows, rows - offset_row)
+                start_col = max(0, -offset_col)
+                end_col = min(cols, cols - offset_col)
+                for r in range(start_row, end_row):
+                    for c in range(start_col, end_col):
+                        i = image[r, c]
+                        # compute the location of the offset pixel
+                        row = r + offset_row
+                        col = c + offset_col
+                        j = image[row, col]
+                        if 0 <= i < levels and 0 <= j < levels:
+                            out[i, j, d_idx, a_idx] += 1
+
+

--- a/cython/requirements.txt
+++ b/cython/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+cython
+numpy
+setuptools

--- a/cython/test_fast_dict.py
+++ b/cython/test_fast_dict.py
@@ -1,0 +1,62 @@
+"""Test fast_dict."""
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+
+import pyximport; pyximport.install()
+
+from cython_fast_dict import IntFloatDict as cython_IntFloatDict
+from cython_fast_dict import argmin as cython_argmin
+
+import pytest
+
+@pytest.mark.parametrize('impl_IntFloatDict',
+                         [cython_IntFloatDict, 
+                          # Put SPy version here
+                          ])
+def test_int_float_dict(impl_IntFloatDict):
+    rng = np.random.RandomState(0)
+    keys = np.unique(rng.randint(100, size=10).astype(np.intp))
+    values = rng.rand(len(keys))
+
+    d = impl_IntFloatDict(keys, values)
+    for key, value in zip(keys, values):
+        assert d[key] == value
+    assert len(d) == len(keys)
+
+    d.append(120, 3.0)
+    assert d[120] == 3.0
+    assert len(d) == len(keys) + 1
+    for i in range(2000):
+        d.append(i + 1000, 4.0)
+    assert d[1100] == 4.0
+
+
+@pytest.mark.parametrize('impl_IntFloatDict,impl_argmin',
+                         [(cython_IntFloatDict, cython_argmin), 
+                          # Put SPy versions here
+                          ])
+def test_int_float_dict_argmin(impl_IntFloatDict, impl_argmin):
+    # Test the argmin implementation on the IntFloatDict
+    keys = np.arange(100, dtype=np.intp)
+    values = np.arange(100, dtype=np.float64)
+    d = impl_IntFloatDict(keys, values)
+    assert impl_argmin(d) == (0, 0)
+
+@pytest.mark.parametrize('impl_IntFloatDict',
+                         [cython_IntFloatDict, 
+                          # Put SPy version here
+                          ])
+def test_to_arrays(impl_IntFloatDict):
+    # Test that an IntFloatDict is converted into arrays
+    # of keys and values correctly
+    keys_in = np.array([1, 2, 3], dtype=np.intp)
+    values_in = np.array([4, 5, 6], dtype=np.float64)
+
+    d = impl_IntFloatDict(keys_in, values_in)
+    keys_out, values_out = d.to_arrays()
+
+    assert keys_out.dtype == keys_in.dtype
+    assert values_in.dtype == values_out.dtype
+    assert_array_equal(keys_out, keys_in)
+    assert_allclose(values_out, values_in)

--- a/cython/test_inner_join.py
+++ b/cython/test_inner_join.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+import pyximport; pyximport.install(setup_args={'include_dirs': np.get_include()})
+
+from cython_inner_join import inner_join as cython_inner_join
+
+import pytest
+
+# From: https://github.com/pandas-dev/pandas/blob/e5898b8d33ac943a60250e1466006c073a506e8c/pandas/tests/libs/test_join.py#L118-L138
+
+@pytest.mark.parametrize('impl_inner_join',
+                         [cython_inner_join, 
+                          # Put SPy version here
+                          ])
+def test_cython_inner_join(impl_inner_join):
+    left = np.array([0, 1, 2, 1, 2, 0, 0, 1, 2, 3, 3], dtype=np.intp)
+    right = np.array([1, 1, 0, 4, 2, 2, 1, 4], dtype=np.intp)
+    max_group = 5
+
+    ls, rs = impl_inner_join(left, right, max_group)
+
+    exp_ls = left.argsort(kind="mergesort")
+    exp_rs = right.argsort(kind="mergesort")
+
+    exp_li = np.array([0, 1, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 7, 7, 8, 8])
+    exp_ri = np.array([0, 0, 0, 1, 2, 3, 1, 2, 3, 1, 2, 3, 4, 5, 4, 5, 4, 5])
+
+    exp_ls = exp_ls.take(exp_li)
+    exp_ls[exp_li == -1] = -1
+
+    exp_rs = exp_rs.take(exp_ri)
+    exp_rs[exp_ri == -1] = -1
+
+    np.testing.assert_array_equal(ls, exp_ls)
+    np.testing.assert_array_equal(rs, exp_rs)

--- a/cython/test_skimage.py
+++ b/cython/test_skimage.py
@@ -1,0 +1,96 @@
+# Based on: https://github.com/scikit-image/scikit-image/blob/866c8794ba86477104e8ed679f66c8e0234677f0/skimage/feature/texture.py#L15
+
+import numpy as np
+
+import pyximport; pyximport.install(setup_args={'include_dirs': np.get_include()})
+
+from cython_skimage_texture import _glcm_loop as cython_glcm_loop
+import pytest
+
+def graycomatrix(impl_glcm_loop, image, distances, angles, levels=None, symmetric=False, normed=False):
+    image = np.ascontiguousarray(image)
+
+    image_max = image.max()
+
+    if np.issubdtype(image.dtype, np.floating):
+        raise ValueError(
+            "Float images are not supported by graycomatrix. "
+            "Convert the image to an unsigned integer type."
+        )
+
+    # for image type > 8bit, levels must be set.
+    if image.dtype not in (np.uint8, np.int8) and levels is None:
+        raise ValueError(
+            "The levels argument is required for data types "
+            "other than uint8. The resulting matrix will be at "
+            "least levels ** 2 in size."
+        )
+
+    if np.issubdtype(image.dtype, np.signedinteger) and np.any(image < 0):
+        raise ValueError("Negative-valued images are not supported.")
+
+    if levels is None:
+        levels = 256
+
+    if image_max >= levels:
+        raise ValueError(
+            "The maximum grayscale value in the image should be "
+            "smaller than the number of levels."
+        )
+
+    distances = np.ascontiguousarray(distances, dtype=np.float64)
+    angles = np.ascontiguousarray(angles, dtype=np.float64)
+
+    P = np.zeros(
+        (levels, levels, len(distances), len(angles)), dtype=np.uint32, order='C'
+    )
+
+    # count co-occurences
+    impl_glcm_loop(image, distances, angles, levels, P)
+
+    # make each GLMC symmetric
+    if symmetric:
+        Pt = np.transpose(P, (1, 0, 2, 3))
+        P = P + Pt
+
+    # normalize each GLCM
+    if normed:
+        P = P.astype(np.float64)
+        glcm_sums = np.sum(P, axis=(0, 1), keepdims=True)
+        glcm_sums[glcm_sums == 0] = 1
+        P /= glcm_sums
+
+    return P
+
+@pytest.fixture
+def image():
+    return np.array(
+        [[0, 0, 1, 1], [0, 0, 1, 1], [0, 2, 2, 2], [2, 2, 3, 3]], dtype=np.uint8
+    )
+
+@pytest.mark.parametrize('impl_glcm_loop',
+                         [cython_glcm_loop, 
+                          # Put SPy version here
+                          ])
+def test_output_angles(image, impl_glcm_loop):
+    result = graycomatrix(
+        impl_glcm_loop,
+        image, [1], [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4], 4
+    )
+    assert result.shape == (4, 4, 1, 4)
+    expected1 = np.array(
+        [[2, 2, 1, 0], [0, 2, 0, 0], [0, 0, 3, 1], [0, 0, 0, 1]], dtype=np.uint32
+    )
+    np.testing.assert_array_equal(result[:, :, 0, 0], expected1)
+    expected2 = np.array(
+        [[1, 1, 3, 0], [0, 1, 1, 0], [0, 0, 0, 2], [0, 0, 0, 0]], dtype=np.uint32
+    )
+    np.testing.assert_array_equal(result[:, :, 0, 1], expected2)
+    expected3 = np.array(
+        [[3, 0, 2, 0], [0, 2, 2, 0], [0, 0, 1, 2], [0, 0, 0, 0]], dtype=np.uint32
+    )
+    np.testing.assert_array_equal(result[:, :, 0, 2], expected3)
+    expected4 = np.array(
+        [[2, 0, 0, 0], [1, 1, 2, 0], [0, 0, 2, 1], [0, 0, 0, 0]], dtype=np.uint32
+    )
+    np.testing.assert_array_equal(result[:, :, 0, 3], expected4)


### PR DESCRIPTION
These are example Cython use cases that we would like to have SPy equivalents of.  Note that we don't need to implement them the same way, but ideally we want equivalent functionality with less (and easier to read) code.

The `test_*` files can be run by pytest and are pre-parameterized to test both the Cython and SPy implementations against each other, whenever the SPy implementation is available.